### PR TITLE
GCC build. Избавляемся от libc + косметика

### DIFF
--- a/bthome_phy6222/Makefile
+++ b/bthome_phy6222/Makefile
@@ -40,22 +40,23 @@ READELF = $(GCC_PATH)arm-none-eabi-readelf
 
 CFLAGS = -Os
 CFLAGS += -W -Wall --std=gnu99
-CFLAGS += --static -nostartfiles -nostdlib
 CFLAGS += -mcpu=cortex-m0 -mthumb -mthumb-interwork
 CFLAGS += -fno-diagnostics-show-caret
 CFLAGS += -fdata-sections -ffunction-sections
 CFLAGS += -funsigned-char -funsigned-bitfields
 CFLAGS += -specs=nosys.specs
 CFLAGS += -Wl,--gc-sections
-CFLAGS += -Wl,--start-group -lgcc -lnosys -Wl,--end-group
 #CFLAGS +=  -MM $(CFLAGS) $(INCFLAGS) $< -MT $@ -MF $(OBJ_DIR)/$(patsubst %.o,%.d,$@)
 
+LDSCRIPT?= $(SDK_PATH)/misc/phy6222.ld
 LDFLAGS += -mcpu=cortex-m0 -mthumb -mthumb-interwork
+LDFLAGS += --static -nostartfiles -nostdlib
 LDFLAGS += -Wl,--gc-sections
-LDFLAGS += -Wl,--start-group -lgcc -lnosys -Wl,--end-group
-LDFLAGS += -Wl,--script=$(SDK_PATH)/misc/phy6222.ld
+LDFLAGS += -Wl,--script=$(LDSCRIPT)
+LDFLAGS += -Wl,--no-warn-rwx-segments
 LDFLAGS += -Wl,--just-symbols=$(SDK_PATH)/misc/bb_rom_sym_m0.gcc
 LDFLAGS += -Wl,-Map=$(OBJ_DIR)/$(PROJECT_NAME).map 
+LIBS    += -Wl,--start-group -lgcc -lnosys -Wl,--end-group
 
 INCLUDES += -I$(SDK_PATH)/misc
 INCLUDES += -I$(SDK_PATH)/misc/CMSIS/include

--- a/bthome_phy6222/SDK/misc/bb_rom_sym_m0.gcc
+++ b/bthome_phy6222/SDK/misc/bb_rom_sym_m0.gcc
@@ -34,6 +34,7 @@ __aeabi_idivmod = 0x00000e35;
 __aeabi_memcpy = 0x00000e81;
 __aeabi_memcpy4 = 0x00000e81;
 __aeabi_memcpy8 = 0x00000e81;
+memcpy = 0x00000e81;
 __aeabi_memset = 0x00000ea5;
 __aeabi_memset4 = 0x00000ea5;
 __aeabi_memset8 = 0x00000ea5;

--- a/bthome_phy6222/SDK/misc/phy6222.ld
+++ b/bthome_phy6222/SDK/misc/phy6222.ld
@@ -18,7 +18,6 @@ SECTIONS
        KEEP(*(jump_table_mem_area))
     } > jumptbl  
 
-
     .gcfgtbl : {
       *(global_config_area)
     } > gcfgtbl
@@ -26,29 +25,6 @@ SECTIONS
     .textentry : {
         *(*.isr_vector)
     } > sram
-
-
-    .init_section : {
-        _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
-        _einit = ABSOLUTE(.);
-    } > flash
-
-    .ARM.extab : {
-        *(.ARM.extab*)
-    } > flash
-
-    __exidx_start = ABSOLUTE(.);
-    .ARM.exidx : {
-        *(.ARM.exidx*)
-    } > flash
-    __exidx_end = ABSOLUTE(.);
-
- 
-    ._sjtblsstore : {
-       _sjtblss = ABSOLUTE(.);
-    } > flash   
-
 
     .data : {
         _sdata = ABSOLUTE(.);
@@ -69,13 +45,7 @@ SECTIONS
 
         *phy_sec_ext.o(.text .text.*)
 
-        *libc.a:lib_a-memset.o(.text.*)
-        *libc.a:lib_a-memcpy-stub.o(.text.*)
-        *libgcc.a:_udivsi3.o(.text)
-        *libgcc.a:_divsi3.o(.text)
-        *libgcc.a:_dvmd_tls.o(.text)
-/*        *libgcc.a:_thumb1_case_sqi.o(.text)
-        *libgcc.a:_thumb1_case_uqi.o(.text) */
+        *libgcc.a:*.o(.text .text.*)
    
         _etextram = ABSOLUTE(.);
 
@@ -94,7 +64,7 @@ SECTIONS
         . = ALIGN(4);
         _ebss = ABSOLUTE(.);
     } > sram
- 
+
  /*   
     .int_stack : {
         . = ALIGN(4);
@@ -120,7 +90,28 @@ SECTIONS
         *(.gcc_except_table)
         *(.gnu.linkonce.r.*)
         _etext = ABSOLUTE(.);
-   } > flash   
+   } > flash
+
+    .init_section : {
+        _sinit = ABSOLUTE(.);
+        *(.init_array .init_array.*)
+        _einit = ABSOLUTE(.);
+    } > flash
+
+    .ARM.extab : {
+        *(.ARM.extab*)
+    } > flash
+
+    __exidx_start = ABSOLUTE(.);
+    .ARM.exidx : {
+        *(.ARM.exidx*)
+    } > flash
+    __exidx_end = ABSOLUTE(.);
+
+ 
+    ._sjtblsstore : {
+       _sjtblss = ABSOLUTE(.);
+    } > flash   
  
     /* Stabs debugging sections. */
     .stab 0 : { *(.stab) }
@@ -137,4 +128,3 @@ SECTIONS
     .debug_aranges 0 : { *(.debug_aranges) }
     
 }
-


### PR DESCRIPTION
1. Избавляемся от _libc_
- подправил _Makefile_ 
- добавил в _SDK/misc/bb_rom_sym_m0.gcc_ `memcpy = 0x00000e81;  /* __aeabi_memcpy */`
2. Запрещаем warning про segment with RWX permissions `LDFLAGS += -Wl,--no-warn-rwx-segments`
3. Косметические правки _SDK/misc/phy6222.ld_

